### PR TITLE
Removed the extra_storage_in_bytes field and the function to measure it

### DIFF
--- a/contracts/nft-simple/src/mint.rs
+++ b/contracts/nft-simple/src/mint.rs
@@ -74,9 +74,7 @@ impl Contract {
         self.token_metadata_by_id.insert(&final_token_id, &metadata);
         self.internal_add_token_to_owner(&token.owner_id, &final_token_id);
 
-        let new_token_size_in_bytes = env::storage_usage() - initial_storage_usage;
-        let required_storage_in_bytes =
-            self.extra_storage_in_bytes_per_token + new_token_size_in_bytes;
+        let required_storage_in_bytes = env::storage_usage() - initial_storage_usage;
 
         refund_deposit(required_storage_in_bytes);
     }


### PR DESCRIPTION
the extra_storage_in_bytes_per_token field made the required storage more than it needed to be when minting. I removed it and the function used for measuring it. 