### PR TITLE
Fixed nft_is_approve logic

### DIFF
--- a/contracts/nft-simple/src/nft_core.rs
+++ b/contracts/nft-simple/src/nft_core.rs
@@ -318,7 +318,7 @@ impl NonFungibleTokenCore for Contract {
 			if let Some(approval_id) = approval_id {
 				approval_id == *approval
 			} else {
-				false
+				true
 			}
 		} else {
 			false


### PR DESCRIPTION
If there was no approval ID passed in but the account ID was in the approval list, it's supposed to return true. This fixes that mistake